### PR TITLE
Clarify member output comment

### DIFF
--- a/GAMBMG.ps1
+++ b/GAMBMG.ps1
@@ -130,7 +130,8 @@ function Show-GroupSummary {
             $includeBlock = "members"
         }
 
-        # Collect aliases and member lines (indented beneath respective headers)
+        # Print alias and member lines (indented beneath respective headers; no
+        #   data is collected)
         elseif ($includeBlock -eq "aliases" -and $trimmed -match "^alias: ") {
             Write-Host "    $trimmed"
         }


### PR DESCRIPTION
## Summary
- update the inline comment in `Show-GroupSummary` to explain that alias and member lines are printed rather than collected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e1f53618832bb2c46f90f7aac8bb